### PR TITLE
fix: convert req.params.id to Number in DELETE route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -46,7 +46,7 @@ app.put('/api/products/:id', (req, res) => {
 
 // Deletar
 app.delete('/api/products/:id', (req, res) => {
-  const idx = products.findIndex(p => p.id === req.params.id);
+  const idx = products.findIndex(p => p.id === Number(req.params.id));
   if (idx === -1) return res.status(404).json({ error: 'Produto não encontrado' });
   products.splice(idx, 1);
   res.status(204).send();


### PR DESCRIPTION
## Problema
A rota `DELETE /api/products/:id` sempre retorna `404 - Produto não encontrado`, mesmo para produtos que existem. O botão Deletar no frontend falha silenciosamente.

## Causa Raiz
`req.params.id` é sempre uma `string` no Express, mas os IDs dos produtos são `number`. A comparação com `===` (strict equality) na linha 49 de `server/index.js` nunca é verdadeira, fazendo `findIndex` retornar `-1`.

## Solução
Adicionado `Number()` para converter `req.params.id` antes da comparação, alinhando a rota DELETE com o padrão já usado nas rotas GET (linha 22) e PUT (linha 40).

## Arquivos Modificados
- `server/index.js` — linha 49

Closes #1

---
*PR gerado automaticamente pela Squad Bug Fix — React & Express (ExpxAgents)*