### PR TITLE
fix: include product ID in PUT request URL for update

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
   }
 
   async function handleUpdate(product) {
-    await fetch(`${API}`, {
+    await fetch(`${API}/${editingProduct.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(product),


### PR DESCRIPTION
## Problema

Ao editar um produto e clicar em **Salvar**, as alterações não são aplicadas. A requisição `PUT` é enviada para `/api/products` (sem o ID) em vez de `/api/products/:id`, fazendo com que o servidor retorne 404 silenciosamente.

Closes #3

## Causa Raiz

A função `handleUpdate` em `client/src/App.jsx` utilizava `${API}` como URL do fetch, sem incluir o ID do produto sendo editado. O servidor Express espera o ID na URL (`PUT /api/products/:id`).

## Solução

Alterada a URL do fetch PUT de `${API}` para `${API}/${editingProduct.id}`, incluindo o ID do produto na requisição de atualização.

## Arquivos Modificados

- `client/src/App.jsx` — função `handleUpdate`, linha 36

## Diff

```diff
-    await fetch(`${API}`, {
+    await fetch(`${API}/${editingProduct.id}`, {
```

---
*PR gerado automaticamente pela Squad Bug Fix — React & Express (ExpxAgents)*