### PR TITLE
fix: convert price to Number in POST /api/products

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ app.post('/api/products', (req, res) => {
   if (!name || price == null || stock == null) {
     return res.status(400).json({ error: 'name, price e stock são obrigatórios' });
   }
-  const product = { id: nextId++, name, price: price, stock: Number(stock) };
+  const product = { id: nextId++, name, price: Number(price), stock: Number(stock) };
   products.push(product);
   res.status(201).json(product);
 });


### PR DESCRIPTION
## Problema
Ao cadastrar um novo produto, a lista trava com `TypeError: product.price.toFixed is not a function` porque o campo `price` é salvo como string no servidor.

## Causa Raiz
Na rota `POST /api/products` do `server/index.js`, o campo `price` era salvo diretamente como string do `req.body` (`price: price`), enquanto `stock` já era convertido com `Number(stock)`. No frontend, `ProductList.jsx` chama `product.price.toFixed(2)`, que só existe em `Number`.

## Solução
Adicionado `Number()` ao campo `price` na criação do produto: `price: Number(price)`.

## Arquivos Modificados
- `server/index.js` — linha 33

## Diff
```diff
-  const product = { id: nextId++, name, price: price, stock: Number(stock) };
+  const product = { id: nextId++, name, price: Number(price), stock: Number(stock) };
```

Closes #5

---
*PR gerado automaticamente pela Squad Bug Fix — React & Express (ExpxAgents)*