### PR TITLE
fix: add guard against undefined products in ProductList component

### DIFF
--- a/client/src/components/ProductList.jsx
+++ b/client/src/components/ProductList.jsx
@@ -1,5 +1,5 @@
 export default function ProductList({ products, onEdit, onDelete }) {
-  if (products.length === 0) {
+  if (!products || products.length === 0) {
     return <p>Nenhum produto cadastrado.</p>;
   }
 


### PR DESCRIPTION
## Problema
O componente `ProductList` quebra com `TypeError: Cannot read properties of undefined (reading 'map')` quando a prop `products` é `undefined` ou quando o estado ainda não foi inicializado.

## Causa Raiz
A verificação `if (products.length === 0)` na linha 2 do componente não protege contra o caso onde `products` é `undefined` ou `null`. Acessar `.length` em `undefined` lança TypeError.

## Solução
Adicionado `!products ||` ao guard existente:
```jsx
if (!products || products.length === 0) {
  return <p>Nenhum produto cadastrado.</p>;
}
```

Isso garante que o componente exibe "Nenhum produto cadastrado." quando `products` é undefined, null ou um array vazio — em vez de crashar.

## Arquivos Modificados
- `client/src/components/ProductList.jsx` — linha 2

Closes #7

---
*PR gerado automaticamente pela Squad Bug Fix — React & Express (ExpxAgents)*