### PR TITLE
fix: add await to handleDelete to prevent stale product list

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -44,7 +44,7 @@ export default function App() {
 
   async function handleDelete(id) {
     if (!window.confirm('Deletar este produto?')) return;
-    fetch(`${API}/${id}`, { method: 'DELETE' });
+    await fetch(`${API}/${id}`, { method: 'DELETE' });
     fetchProducts();
   }
 


### PR DESCRIPTION
## Problema
Ao deletar um produto, ele continua aparecendo na lista porque `fetchProducts()` é chamado antes da requisição DELETE completar no servidor.

**Issue:** #9

## Causa Raiz
O `await` foi removido da chamada `fetch` no `handleDelete` em `client/src/App.jsx`, fazendo com que `fetchProducts()` execute imediatamente sem aguardar a conclusão do DELETE. Isso causa uma race condition onde o GET retorna o produto que ainda não foi deletado.

## Solução
Restaurado o `await` antes do `fetch` de deleção, garantindo que a lista só seja atualizada após o servidor confirmar a exclusão.

```diff
   async function handleDelete(id) {
     if (!window.confirm('Deletar este produto?')) return;
-    fetch(`${API}/${id}`, { method: 'DELETE' });
+    await fetch(`${API}/${id}`, { method: 'DELETE' });
     fetchProducts();
   }
```

A correção é consistente com `handleCreate` e `handleUpdate`, que já usam `await` corretamente.

## Arquivos Modificados
- `client/src/App.jsx` — função `handleDelete`, linha 47

Closes #9

---
*PR gerado automaticamente por [ExpxAgents](https://github.com/expxagents) — Squad Bug Fix v1.0.0*
